### PR TITLE
:bug: Fixed bug that allowed users to conenct to sensible pages after logging out

### DIFF
--- a/ClientApplication/src/main/java/com/champix/clientchampix/controller/AuthentificationController.java
+++ b/ClientApplication/src/main/java/com/champix/clientchampix/controller/AuthentificationController.java
@@ -69,6 +69,7 @@ public class AuthentificationController {
         {
             HttpSession session = request.getSession();
             session.removeAttribute("id");
+            session.removeAttribute("jwt");
             destinationPage = "/index";
         }
         return new ModelAndView(destinationPage);

--- a/ClientApplication/src/main/java/com/champix/clientchampix/controller/ReservationController.java
+++ b/ClientApplication/src/main/java/com/champix/clientchampix/controller/ReservationController.java
@@ -91,17 +91,6 @@ public class ReservationController {
         }
         return new ModelAndView(destinationPage);
     }
-    
-    private boolean checkJWTSession(HttpServletRequest request) {
-        HttpSession session = request.getSession();
-        if (!JWTManager.verify((String) session.getAttribute("jwt"))) {
-            session.setAttribute("id", null);
-            session.setAttribute("jwt", null);
-            request.setAttribute("error", "Session expired");
-            return false;
-        }
-        return true;
-    }
 
     @RequestMapping(method = RequestMethod.GET, value = "/reservations")
     public ModelAndView getAllReservationUser(HttpServletRequest request,
@@ -122,5 +111,16 @@ public class ReservationController {
             destinationPage = "views/error";
         }
         return new ModelAndView(destinationPage);
+    }
+    
+    private boolean checkJWTSession(HttpServletRequest request) {
+        HttpSession session = request.getSession();
+        if (session.getAttribute("id") == null || !JWTManager.verify((String) session.getAttribute("jwt"))) {
+            session.removeAttribute("id");
+            session.removeAttribute("jwt");
+            request.setAttribute("error", "Session expired");
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
After logging out, the sensible pages such as "*reservations*" were still available. THat was caused by the fact that the function `logout` did not suppress the JWT token and by the lack of ID-check before sending sensible pages.

Modifications made:

* Removed the JWT field when logging out.
* Check before sending sensible pages if ID is set.